### PR TITLE
Align heap base on an 8-byte offset.

### DIFF
--- a/hw/mcu/atmel/samd21xx/samd21xx.ld
+++ b/hw/mcu/atmel/samd21xx/samd21xx.ld
@@ -160,6 +160,7 @@ SECTIONS
     } > RAM
 
     /* Heap starts after BSS */
+    . = ALIGN(8);    
     __HeapBase = .;
 
   /* User_heap_stack section, used to check that there is enough RAM left */


### PR DESCRIPTION
The MCU linker scripts were only imposing 4-byte alignment on the heap base, rather than 8-byte alignment.  This caused `malloc()` to return pointers that were not 8-byte aligned.  This is problematic if the pointer were subsequently used to access data that requires 8-byte alignment (e.g., a `double`).

From n1570 (c11 draft), 7.22.3 (Memory management functions):

> The pointer returned if the allocation succeeds is suitably aligned so that it may be assigned to a pointer to any type of object with a fundamental alignment requirement

By locating the heap base at an offset of 8, we ensure `_sbrk()` only returns 8-byte aligned memory blocks.

`malloc()` itself already imposes a greater restriction on itself: it only allocates blocks whose size is a multiple of 16.  So, as long as `_sbrk()` gives malloc properly aligned blocks, `malloc()` will return properly aligned pointers to the application.
