### PR TITLE
Add SVC IRQ name to mcu.h to avoid naming issues

### DIFF
--- a/hw/mcu/atmel/samd21xx/include/mcu/mcu.h
+++ b/hw/mcu/atmel/samd21xx/include/mcu/mcu.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+#define SVC_IRQ_NUMBER SVCall_IRQn
+
 /*
  * Defines for naming GPIOs.
  */


### PR DESCRIPTION
Related to: https://github.com/apache/mynewt-core/pull/1281