### PR TITLE
samd21xxx; recent changes in mynewt cause min() to be defined earlier

### DIFF
--- a/hw/mcu/atmel/samd21xx/src/sam0/utils/compiler.h
+++ b/hw/mcu/atmel/samd21xx/src/sam0/utils/compiler.h
@@ -742,7 +742,9 @@ typedef struct
  *
  * \note More optimized if only used with values unknown at compile time.
  */
+#ifndef min
 #define min(a, b)   Min(a, b)
+#endif
 
 /** \brief Takes the maximal value of \a a and \a b.
  *
@@ -753,7 +755,9 @@ typedef struct
  *
  * \note More optimized if only used with values unknown at compile time.
  */
+#ifndef max
 #define max(a, b)   Max(a, b)
+#endif
 #endif
 
 /** @} */


### PR DESCRIPTION
than this file. Make the #define in samd21xx to be conditional.