### PR TITLE
hw/mcu: Prevent redefinition of __always_inline macro

### DIFF
--- a/hw/mcu/atmel/samd21xx/src/sam0/utils/compiler.h
+++ b/hw/mcu/atmel/samd21xx/src/sam0/utils/compiler.h
@@ -137,7 +137,9 @@
 #if defined(__CC_ARM)
 #  define __always_inline             __forceinline
 #elif (defined __GNUC__)
+#ifndef __always_inline
 #  define __always_inline             __attribute__((__always_inline__))
+#endif
 #elif (defined __ICCARM__)
 #  define __always_inline             _Pragma("inline=forced")
 #endif


### PR DESCRIPTION
Added a check before defining the `__always_inline` macro, so it doesnt conflict with definitions from toolchains.
This prevents build errors when the macro already exists.

Tested with: arm-none-eabi-gcc version 14.2